### PR TITLE
Add metric upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,24 @@ Setup for Kubernetes (AKS) deployment
     * `--storage` option to pass the Azure storage connection string
     * `--ikey` option if Application Insights is used to monitor the application
     * `--tag` option to use custom image tag (avoiding the 'latest" default value)
+
+Notes:
+* The chart uses a fluentD-based sidecar to collect logs and send them to Application Insights. 
+Building the Docker image for the sidecar is not part of the deployment script. 
+You can build the image manually using the sources at 
+https://github.com/yantang-msft/kubernetes-sidecar-diagnostics/tree/scratch/FluentdAgent
+* The chart also uses a Telegraf agent to send metrics to Application Insights. 
+Agent sources are available from https://github.com/karolz-ms/telegraf/tree/AIOutput 
+    
+    To build the agent on the Mac:
+         
+    1. Telegraf requires to be put under GOPATH/src--see instructions on their Github site. Also, when a cloned repo is used, the local source still needs to be under influxdata/telegraf. So instead of `go get -d github.com/influxdata/telegraf`, use 
+	
+        `git clone https://github.com/karolz-ms/telegraf.git influxdata/telegraf`
+    
+        (from GOPATH/src)
+
+    1. Check out `AIOutput` branch
+    1. Set GOOS and GOARCH environment variables to compile for the right architecture (e.g. `linux` and `amd64`, respectively). For more info see https://golang.org/doc/install/source#environment 
+    1. `make`
+    1. `docker build --tag desired-tag .`

--- a/airplanesvc/Program.cs
+++ b/airplanesvc/Program.cs
@@ -21,7 +21,7 @@ namespace airplanesvc
                     metricOptions.GlobalTags.Add("service-name", nameof(airplanesvc));
                 });
 
-                builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused");
+                builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused", TimeSpan.FromSeconds(1));
                 // DEBUG builder.Report.ToConsole(TimeSpan.FromSeconds(1));
             })
 

--- a/airplanesvc/Program.cs
+++ b/airplanesvc/Program.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using App.Metrics;
+using App.Metrics.AspNetCore;
 
 namespace airplanesvc
 {
@@ -18,9 +21,28 @@ namespace airplanesvc
         }
 
         public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .UseApplicationInsights()
-                .Build();
+        WebHost.CreateDefaultBuilder(args)
+            .ConfigureMetricsWithDefaults(builder => {
+                // builder.Report.ToInfluxDb("http://telegraf-ai:8186", "dbname_unused");
+                builder.Report.ToConsole(TimeSpan.FromSeconds(1));
+            })
+            .UseMetrics(options => {
+               options.EndpointOptions = (endpointOptions) => {
+                   endpointOptions.EnvironmentInfoEndpointEnabled = false;
+                   endpointOptions.MetricsEndpointEnabled = false;
+                   endpointOptions.MetricsTextEndpointEnabled = true;
+               };
+
+               options.TrackingMiddlewareOptions = (trackingOptions) => {
+                   trackingOptions.ApdexTrackingEnabled = false;
+                   // trackingOptions.ApdexTSeconds = 1.0;
+                   trackingOptions.IgnoredHttpStatusCodes.Add((int) HttpStatusCode.NotFound);
+                   trackingOptions.OAuth2TrackingEnabled = false;
+               };
+            })
+            .UseStartup<Startup>()
+            .UseApplicationInsights()
+            .Build();
+
     }
 }

--- a/airplanesvc/Program.cs
+++ b/airplanesvc/Program.cs
@@ -17,17 +17,22 @@ namespace airplanesvc
         public static IWebHost BuildWebHost(string[] args) =>
         WebHost.CreateDefaultBuilder(args)
             .ConfigureMetricsWithDefaults(builder => {
-                // builder.Report.ToInfluxDb("http://telegraf-ai:8186", "dbname_unused");
-                builder.Report.ToConsole(TimeSpan.FromSeconds(1));
+                builder.Configuration.Configure(metricOptions => {
+                    metricOptions.GlobalTags.Add("service-name", nameof(airplanesvc));
+                });
+
+                builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused");
+                // DEBUG builder.Report.ToConsole(TimeSpan.FromSeconds(1));
             })
-            .UseMetrics(options => {
-               options.EndpointOptions = (endpointOptions) => {
+
+            .UseMetrics(webHostMetricOptions => {
+               webHostMetricOptions.EndpointOptions = (endpointOptions) => {
                    endpointOptions.EnvironmentInfoEndpointEnabled = false;
                    endpointOptions.MetricsEndpointEnabled = false;
                    endpointOptions.MetricsTextEndpointEnabled = true;
                };
 
-               options.TrackingMiddlewareOptions = (trackingOptions) => {
+               webHostMetricOptions.TrackingMiddlewareOptions = (trackingOptions) => {
                    trackingOptions.ApdexTrackingEnabled = false;
                    // trackingOptions.ApdexTSeconds = 1.0;
                    trackingOptions.IgnoredHttpStatusCodes.Add((int) HttpStatusCode.NotFound);

--- a/airplanesvc/Program.cs
+++ b/airplanesvc/Program.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using App.Metrics;
 using App.Metrics.AspNetCore;
 

--- a/airplanesvc/Startup.cs
+++ b/airplanesvc/Startup.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.ApplicationInsights.Extensibility;
+using App.Metrics;
 
 using AirTrafficControl.Interfaces;
 using CustomOutputs.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 
 namespace airplanesvc
 {
@@ -21,9 +23,10 @@ namespace airplanesvc
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().AddJsonOptions(options => {
-                options.SerializerSettings.ApplyAtcSerializerSettings();
-            });
+            services
+                .AddMvc(options => options.AddMetricsResourceFilter())
+                .AddJsonOptions(options => options.SerializerSettings.ApplyAtcSerializerSettings());
+            
             services.AddSingleton<AirplaneRepository>(serviceProvider => new AirplaneRepository());
         }
 

--- a/airplanesvc/Startup.cs
+++ b/airplanesvc/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ApplicationInsights.Extensibility;
-using App.Metrics;
 
 using AirTrafficControl.Interfaces;
 using CustomOutputs.ApplicationInsights;

--- a/airplanesvc/airplanesvc.csproj
+++ b/airplanesvc/airplanesvc.csproj
@@ -12,6 +12,12 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Validation" Version="2.4.18" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Endpoints" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Reporting" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Tracking" Version="2.0.0-preview1" /> 
+    <PackageReference Include="App.Metrics.Reporting.Console" Version="2.0.0-preview1" /> 
+    <PackageReference Include="App.Metrics.Reporting.InfluxDB" Version="2.0.0-preview1" /> 
   </ItemGroup>
 
   <ItemGroup>

--- a/atcsvc/Program.cs
+++ b/atcsvc/Program.cs
@@ -17,18 +17,22 @@ namespace atcsvc
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                   .ConfigureMetricsWithDefaults(builder => {
-                    // builder.Report.ToInfluxDb("http://telegraf-ai:8186", "dbname_unused");
-                    builder.Report.ToConsole(TimeSpan.FromSeconds(1));
+                .ConfigureMetricsWithDefaults(builder => {
+                   builder.Configuration.Configure(metricOptions => {
+                       metricOptions.GlobalTags.Add("service-name", nameof(atcsvc)); 
+                   });
+            
+                    builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused");
+                    // DEBUG builder.Report.ToConsole(TimeSpan.FromSeconds(1));
                 })
-                .UseMetrics(options => {
-                    options.EndpointOptions = (endpointOptions) => {
+                .UseMetrics(webHostMetricOptions => {
+                    webHostMetricOptions.EndpointOptions = (endpointOptions) => {
                         endpointOptions.EnvironmentInfoEndpointEnabled = false;
                         endpointOptions.MetricsEndpointEnabled = false;
                         endpointOptions.MetricsTextEndpointEnabled = true;
                     };
 
-                    options.TrackingMiddlewareOptions = (trackingOptions) => {
+                    webHostMetricOptions.TrackingMiddlewareOptions = (trackingOptions) => {
                         trackingOptions.ApdexTrackingEnabled = false;
                         // trackingOptions.ApdexTSeconds = 1.0;
                         trackingOptions.IgnoredHttpStatusCodes.Add((int) HttpStatusCode.NotFound);

--- a/atcsvc/Program.cs
+++ b/atcsvc/Program.cs
@@ -1,5 +1,10 @@
-﻿using Microsoft.AspNetCore;
+﻿using System;
+using System.Net;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using App.Metrics;
+using App.Metrics.AspNetCore;
+
 
 namespace atcsvc
 {
@@ -12,6 +17,24 @@ namespace atcsvc
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                   .ConfigureMetricsWithDefaults(builder => {
+                    // builder.Report.ToInfluxDb("http://telegraf-ai:8186", "dbname_unused");
+                    builder.Report.ToConsole(TimeSpan.FromSeconds(1));
+                })
+                .UseMetrics(options => {
+                    options.EndpointOptions = (endpointOptions) => {
+                        endpointOptions.EnvironmentInfoEndpointEnabled = false;
+                        endpointOptions.MetricsEndpointEnabled = false;
+                        endpointOptions.MetricsTextEndpointEnabled = true;
+                    };
+
+                    options.TrackingMiddlewareOptions = (trackingOptions) => {
+                        trackingOptions.ApdexTrackingEnabled = false;
+                        // trackingOptions.ApdexTSeconds = 1.0;
+                        trackingOptions.IgnoredHttpStatusCodes.Add((int) HttpStatusCode.NotFound);
+                        trackingOptions.OAuth2TrackingEnabled = false;
+                    };
+                })
                 .UseStartup<Startup>()
                 .UseApplicationInsights()
                 .Build();

--- a/atcsvc/Program.cs
+++ b/atcsvc/Program.cs
@@ -22,7 +22,7 @@ namespace atcsvc
                        metricOptions.GlobalTags.Add("service-name", nameof(atcsvc)); 
                    });
             
-                    builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused");
+                    builder.Report.ToInfluxDb("http://localhost:8186", "dbname_unused", TimeSpan.FromSeconds(1));
                     // DEBUG builder.Report.ToConsole(TimeSpan.FromSeconds(1));
                 })
                 .UseMetrics(webHostMetricOptions => {

--- a/atcsvc/Startup.cs
+++ b/atcsvc/Startup.cs
@@ -1,20 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using System.Reactive.Subjects;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
-using Validation;
-
-using atcsvc.TableStorage;
-using AirTrafficControl.Interfaces;
 using Microsoft.ApplicationInsights.Extensibility;
+
+using AirTrafficControl.Interfaces;
 using CustomOutputs.ApplicationInsights;
 
 namespace atcsvc
@@ -35,9 +28,9 @@ namespace atcsvc
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().AddJsonOptions(options => {
-                options.SerializerSettings.ApplyAtcSerializerSettings();
-            });
+            services
+                .AddMvc(options => options.AddMetricsResourceFilter())
+                .AddJsonOptions(options => options.SerializerSettings.ApplyAtcSerializerSettings());
             services.AddSingleton<ISubject<Airplane>>(airplaneStateEventAggregator_);
             services.AddSingleton<AtcSvc>();
         }

--- a/atcsvc/atcsvc.csproj
+++ b/atcsvc/atcsvc.csproj
@@ -17,6 +17,12 @@
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
     <PackageReference Include="Validation" Version="2.4.18" />
     <PackageReference Include="Polly" Version="5.8.0" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Endpoints" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Reporting" Version="2.0.0-preview1" />
+    <PackageReference Include="App.Metrics.AspNetCore.Tracking" Version="2.0.0-preview1" /> 
+    <PackageReference Include="App.Metrics.Reporting.Console" Version="2.0.0-preview1" /> 
+    <PackageReference Include="App.Metrics.Reporting.InfluxDB" Version="2.0.0-preview1" /> 
   </ItemGroup>
 
   <ItemGroup>

--- a/k8s/atcApp/config-files/telegraf.conf
+++ b/k8s/atcApp/config-files/telegraf.conf
@@ -76,11 +76,12 @@
 
 [[outputs.application_insights]]
 
-[[outputs.file]]
+# [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
-  files = ["stdout"]
-  data_format = "json"
-  json_timestamp_units = "1ms"
+  ## This is useful mainly for diagnosing problems
+#  files = ["stdout"]
+#  data_format = "json"
+#  json_timestamp_units = "1ms"
 
 
 ###############################################################################

--- a/k8s/atcApp/templates/airplanesvc.yaml
+++ b/k8s/atcApp/templates/airplanesvc.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: airplanesvc
           image: {{ .Values.container_registry }}/airplanesvc:{{ .Values.image_tag | trim }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 5024
           env:
@@ -41,6 +41,7 @@ spec:
             periodSeconds: 60
         - name: fluentdsidecar
           image: {{ .Values.container_registry }}/fluentdsidecar:{{ .Values.image_tag | trim }}
+          imagePullPolicy: Always
           env:
             - name: INSTRUMENTATION_KEY
               valueFrom:
@@ -51,6 +52,7 @@ spec:
               value: airplanesvc
         - name: telegrafsidecar
           image: {{ .Values.container_registry }}/telegraf:{{ .Values.image_tag | trim }}
+          imagePullPolicy: Always
           env:
             - name: APPINSIGHTS_INSTRUMENTATIONKEY
               valueFrom:

--- a/k8s/atcApp/templates/airplanesvc.yaml
+++ b/k8s/atcApp/templates/airplanesvc.yaml
@@ -49,3 +49,21 @@ spec:
                   key: appinsights_instrumentationkey
             - name: SOURCE_CONTAINER_NAME
               value: airplanesvc
+        - name: telegrafsidecar
+          image: {{ .Values.container_registry }}/telegraf:{{ .Values.image_tag | trim }}
+          env:
+            - name: APPINSIGHTS_INSTRUMENTATIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: atc-secrets
+                  key: appinsights_instrumentationkey
+          volumeMounts:
+          - name: config
+            mountPath: /etc/telegraf
+      volumes:
+      - name: config
+        configMap:
+          name: config-files
+          items:
+          - key: telegraf.conf
+            path: telegraf.conf

--- a/k8s/atcApp/templates/atcsvc.yaml
+++ b/k8s/atcApp/templates/atcsvc.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: atcsvc
           image: {{ .Values.container_registry }}/atcsvc:{{ .Values.image_tag | trim }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 5023
           env:
@@ -47,6 +47,7 @@ spec:
             periodSeconds: 60
         - name: fluentdsidecar
           image: {{ .Values.container_registry }}/fluentdsidecar:{{ .Values.image_tag | trim }}
+          imagePullPolicy: Always
           env:
             - name: INSTRUMENTATION_KEY
               valueFrom:
@@ -57,6 +58,7 @@ spec:
               value: atcsvc
         - name: telegrafsidecar
           image: {{ .Values.container_registry }}/telegraf:{{ .Values.image_tag | trim }}
+          imagePullPolicy: Always
           env:
             - name: APPINSIGHTS_INSTRUMENTATIONKEY
               valueFrom:

--- a/k8s/atcApp/templates/atcsvc.yaml
+++ b/k8s/atcApp/templates/atcsvc.yaml
@@ -55,4 +55,21 @@ spec:
                   key: appinsights_instrumentationkey
             - name: SOURCE_CONTAINER_NAME
               value: atcsvc
-
+        - name: telegrafsidecar
+          image: {{ .Values.container_registry }}/telegraf:{{ .Values.image_tag | trim }}
+          env:
+            - name: APPINSIGHTS_INSTRUMENTATIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: atc-secrets
+                  key: appinsights_instrumentationkey
+          volumeMounts:
+          - name: config
+            mountPath: /etc/telegraf
+      volumes:
+      - name: config
+        configMap:
+          name: config-files
+          items:
+          - key: telegraf.conf
+            path: telegraf.conf


### PR DESCRIPTION
Metrics are produced by [AppMetrics library](https://www.app-metrics.io/getting-started/) and sent to Application Insights via Telegraf, using [a custom output](https://github.com/karolz-ms/telegraf/tree/AIOutput)

Known issue: services keep sending metrics even when there is no traffic (metric buffer is not being flushed properly?)