### PR TITLE
Make the frontend app stable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ATCSVC_SERVICE_HOST=localhost
       - ATCSVC_SERVICE_PORT=5023
     ports:
-      - 5022:80
+      - 5022:5000
 
   atcsvc:
     image: atc/atcsvc:${TAG:-latest}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,15 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.6
-
-RUN  pip install flask \
+FROM python:3.6.4
+WORKDIR /usr/src/app
+EXPOSE 5000
+RUN  pip install --upgrade pip \
+     && pip install flask \
      && pip install flask-socketio \
+     && pip install gevent \
+     && pip install gevent-websocket \
      && pip install requests
 
-ADD  ./frontend /app
+# Set PYTHONUNBUFFERED to 0 we see console output asap
+ENV PYTHONUNBUFFERED=0
+ENV FLASK_APP=./main.py
+COPY ./frontend ./
+CMD ["flask", "run", "-h", "0.0.0.0"]

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -5,7 +5,7 @@
     <title>Air Traffic Control</title>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.4/socket.io.js"></script>
-    <script src="static/js/application.js"></script>
+    <script src="/static/js/application.js"></script>
     <script language="JavaScript">
         function send(form){
         }

--- a/k8s/atcApp/templates/frontend.yaml
+++ b/k8s/atcApp/templates/frontend.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - port: 5022
-      targetPort: 80
+      targetPort: 5000
   selector:
     app: atcApp
     component: frontend


### PR DESCRIPTION
Finally got a stable frontend app. We can now refresh the page or open multiple tabs without problem.

The main change is around the docker file, which use the standard python image instead of an "optimized" image, this solves the problem that the state is not persisted.
Also choose gevent as the webserver, without this package, the socket session is not stable and may not receive updates from server.

I'd like to merge it to the master branch first. If it can be validated to be working well, we can consider update the march_demo branch.